### PR TITLE
feat: create chat and send message

### DIFF
--- a/src/common/decorators/get-user-id.ts
+++ b/src/common/decorators/get-user-id.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const GetUserId = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): string => {
+    const request = ctx.switchToHttp().getRequest();
+
+    return request.user.id;
+  },
+);

--- a/src/modules/chat/chat.controller.ts
+++ b/src/modules/chat/chat.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, UseGuards, Request, Param } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  UseGuards,
+  Param,
+  Post,
+  Body,
+  Query,
+} from '@nestjs/common';
 import {
   ApiOperation,
   ApiOkResponse,
@@ -12,14 +20,10 @@ import { JwtAuthGuard } from '../auth/auth.guard';
 
 import { ChatService } from './chat.service';
 import { ChatRoomResponseDto } from './dto/chat-room-response.dto';
+import { CreateChatDto } from './dto/create-chat.dto';
+import { ChatRoom } from './entities/chat-room.entity';
 
-type AuthenticatedUser = {
-  user: {
-    id: string;
-  };
-} & Request;
-
-UseGuards(JwtAuthGuard);
+@UseGuards(JwtAuthGuard)
 @Controller('chats')
 export class ChatController {
   constructor(private readonly chatService: ChatService) {}
@@ -72,10 +76,8 @@ export class ChatController {
     },
   })
   async getUserChats(
-    @Request() req: AuthenticatedUser,
+    @Query('userId') userId: string,
   ): Promise<ChatRoomResponseDto[]> {
-    const userId = req.user.id;
-
     return this.chatService.getUserChats(userId);
   }
 
@@ -132,10 +134,52 @@ export class ChatController {
   })
   async getChatById(
     @Param('id') chatId: string,
-    @Request() req: AuthenticatedUser,
+    @Query('userId') userId: string,
   ): Promise<ChatRoomResponseDto> {
-    const userId = req.user.id;
-
     return this.chatService.getChatById(chatId, userId);
+  }
+
+  @Post()
+  @ApiOperation({
+    summary: 'Create a new chat room',
+    tags: ['Chat Endpoints'],
+    description: 'This endpoint creates a new chat room between two users.',
+  })
+  @ApiOkResponse({
+    description: 'The newly created chat room',
+    type: ChatRoom,
+  })
+  @ApiNotFoundResponse({
+    description: 'One or both users not found',
+    schema: {
+      properties: {
+        statusCode: { type: 'integer', example: 404 },
+        message: { type: 'string', example: 'User not found' },
+        error: { type: 'string', example: 'Not Found' },
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Unauthorized - No token or invalid token or expired token',
+    schema: {
+      properties: {
+        statusCode: { type: 'integer', example: 401 },
+        message: { type: 'string', example: 'Unauthorized' },
+        error: { type: 'string', example: 'Unauthorized' },
+      },
+    },
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Failed to create chat room',
+    schema: {
+      properties: {
+        statusCode: { type: 'integer', example: 500 },
+        message: { type: 'string', example: 'Failed to create chat room' },
+        error: { type: 'string', example: 'Internal Server Error' },
+      },
+    },
+  })
+  async createChat(@Body() createChatDto: CreateChatDto): Promise<ChatRoom> {
+    return this.chatService.createChat(createChatDto);
   }
 }

--- a/src/modules/chat/chat.controller.ts
+++ b/src/modules/chat/chat.controller.ts
@@ -14,6 +14,7 @@ import {
   ApiUnauthorizedResponse,
   ApiInternalServerErrorResponse,
   ApiParam,
+  ApiTags,
 } from '@nestjs/swagger';
 
 import { JwtAuthGuard } from '../auth/auth.guard';
@@ -23,6 +24,7 @@ import { ChatRoomResponseDto } from './dto/chat-room-response.dto';
 import { CreateChatDto } from './dto/create-chat.dto';
 import { ChatRoom } from './entities/chat-room.entity';
 
+@ApiTags('chats')
 @UseGuards(JwtAuthGuard)
 @Controller('chats')
 export class ChatController {

--- a/src/modules/chat/chat.controller.ts
+++ b/src/modules/chat/chat.controller.ts
@@ -1,12 +1,4 @@
-import {
-  Controller,
-  Get,
-  UseGuards,
-  Param,
-  Post,
-  Body,
-  Query,
-} from '@nestjs/common';
+import { Controller, Get, UseGuards, Param } from '@nestjs/common';
 import {
   ApiOperation,
   ApiOkResponse,
@@ -17,12 +9,12 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
+import { GetUserId } from 'src/common/decorators/get-user-id';
+
 import { JwtAuthGuard } from '../auth/auth.guard';
 
 import { ChatService } from './chat.service';
 import { ChatRoomResponseDto } from './dto/chat-room-response.dto';
-import { CreateChatDto } from './dto/create-chat.dto';
-import { ChatRoom } from './entities/chat-room.entity';
 
 @ApiTags('chats')
 @UseGuards(JwtAuthGuard)
@@ -78,7 +70,7 @@ export class ChatController {
     },
   })
   async getUserChats(
-    @Query('userId') userId: string,
+    @GetUserId() userId: string,
   ): Promise<ChatRoomResponseDto[]> {
     return this.chatService.getUserChats(userId);
   }
@@ -136,52 +128,8 @@ export class ChatController {
   })
   async getChatById(
     @Param('id') chatId: string,
-    @Query('userId') userId: string,
+    @GetUserId() userId: string,
   ): Promise<ChatRoomResponseDto> {
     return this.chatService.getChatById(chatId, userId);
-  }
-
-  @Post()
-  @ApiOperation({
-    summary: 'Create a new chat room',
-    tags: ['Chat Endpoints'],
-    description: 'This endpoint creates a new chat room between two users.',
-  })
-  @ApiOkResponse({
-    description: 'The newly created chat room',
-    type: ChatRoom,
-  })
-  @ApiNotFoundResponse({
-    description: 'One or both users not found',
-    schema: {
-      properties: {
-        statusCode: { type: 'integer', example: 404 },
-        message: { type: 'string', example: 'User not found' },
-        error: { type: 'string', example: 'Not Found' },
-      },
-    },
-  })
-  @ApiUnauthorizedResponse({
-    description: 'Unauthorized - No token or invalid token or expired token',
-    schema: {
-      properties: {
-        statusCode: { type: 'integer', example: 401 },
-        message: { type: 'string', example: 'Unauthorized' },
-        error: { type: 'string', example: 'Unauthorized' },
-      },
-    },
-  })
-  @ApiInternalServerErrorResponse({
-    description: 'Failed to create chat room',
-    schema: {
-      properties: {
-        statusCode: { type: 'integer', example: 500 },
-        message: { type: 'string', example: 'Failed to create chat room' },
-        error: { type: 'string', example: 'Internal Server Error' },
-      },
-    },
-  })
-  async createChat(@Body() createChatDto: CreateChatDto): Promise<ChatRoom> {
-    return this.chatService.createChat(createChatDto);
   }
 }

--- a/src/modules/chat/chat.module.ts
+++ b/src/modules/chat/chat.module.ts
@@ -13,5 +13,6 @@ import { Message } from './entities/message.entity';
   imports: [TypeOrmModule.forFeature([ChatRoom, Message, User]), UsersModule],
   controllers: [ChatController],
   providers: [ChatService],
+  exports: [ChatService],
 })
 export class ChatModule {}

--- a/src/modules/chat/dto/chat-room-response.dto.ts
+++ b/src/modules/chat/dto/chat-room-response.dto.ts
@@ -4,21 +4,16 @@ import { ChatUserDto } from './chat-user.dto';
 import { MessageResponseDto } from './message-response.dto';
 
 export class ChatRoomResponseDto {
-  @ApiProperty({
-    example: '61c674384-f944-401b-949b-b76e8793bdc9',
-    description: 'The ID of the chat room',
-  })
+  @ApiProperty()
   id: string;
 
-  @ApiProperty({
-    type: () => ChatUserDto,
-    description: 'The chat partner in the chat room',
-  })
+  @ApiProperty()
   chatPartner: ChatUserDto;
 
-  @ApiProperty({
-    type: () => [MessageResponseDto],
-    description: 'The last message in the chat room',
-  })
+  @ApiProperty()
   messages: MessageResponseDto[];
+
+  constructor(partial: Partial<ChatRoomResponseDto>) {
+    Object.assign(this, partial);
+  }
 }

--- a/src/modules/chat/dto/chat-room-response.dto.ts
+++ b/src/modules/chat/dto/chat-room-response.dto.ts
@@ -4,13 +4,22 @@ import { ChatUserDto } from './chat-user.dto';
 import { MessageResponseDto } from './message-response.dto';
 
 export class ChatRoomResponseDto {
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Unique identifier of the chat room',
+    example: '7b4b5875-2d0c-4bee-924a-1bdc7e6d3ef4',
+  })
   id: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Details of the chat partner',
+    type: ChatUserDto,
+  })
   chatPartner: ChatUserDto;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'List of messages in the chat room',
+    type: [MessageResponseDto],
+  })
   messages: MessageResponseDto[];
 
   constructor(partial: Partial<ChatRoomResponseDto>) {

--- a/src/modules/chat/dto/chat-user.dto.ts
+++ b/src/modules/chat/dto/chat-user.dto.ts
@@ -1,21 +1,18 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+import { UserResponseDto } from 'src/modules/auth/dto/user-response.dto';
+
 export class ChatUserDto {
-  @ApiProperty({
-    example: '61c674384-f944-401b-949b-b76e8793bdc9',
-    description: 'The ID of the chat partner',
-  })
+  @ApiProperty()
   id: string;
 
-  @ApiProperty({
-    example: 'John Doe',
-    description: 'The name of the chat partner',
-  })
+  @ApiProperty()
   name: string;
 
-  @ApiProperty({
-    example: 'file-1718301871158-882823500.jpg',
-    description: 'The photo URL of the chat partner',
-  })
+  @ApiProperty()
   photoUrl: string;
+
+  constructor(partial: Partial<UserResponseDto>) {
+    Object.assign(this, partial);
+  }
 }

--- a/src/modules/chat/dto/chat-user.dto.ts
+++ b/src/modules/chat/dto/chat-user.dto.ts
@@ -1,18 +1,25 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { UserResponseDto } from 'src/modules/auth/dto/user-response.dto';
-
 export class ChatUserDto {
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Unique identifier of the user',
+    example: '3d14ab90-3182-4cd5-bae4-08b97832a8b9',
+  })
   id: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Name of the user',
+    example: 'John Doe',
+  })
   name: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: "URL of the user's profile photo",
+    example: 'https://example.com/uploads/avatars/user-photo.jpeg',
+  })
   photoUrl: string;
 
-  constructor(partial: Partial<UserResponseDto>) {
+  constructor(partial: Partial<ChatUserDto>) {
     Object.assign(this, partial);
   }
 }

--- a/src/modules/chat/dto/create-chat.dto.ts
+++ b/src/modules/chat/dto/create-chat.dto.ts
@@ -5,17 +5,9 @@ import { IsNotEmpty, IsUUID } from 'class-validator';
 export class CreateChatDto {
   @ApiProperty({
     example: '61c674384-f944-401b-949b-b76e8793bdc9',
-    description: 'The ID of the first user',
-  })
-  @IsNotEmpty()
-  @IsUUID()
-  userId1: string;
-
-  @ApiProperty({
-    example: '61c674384-f944-401b-949b-b76e8793bdc9',
     description: 'The ID of the second user',
   })
   @IsNotEmpty()
   @IsUUID()
-  userId2: string;
+  chatPartnerId: string;
 }

--- a/src/modules/chat/dto/create-chat.dto.ts
+++ b/src/modules/chat/dto/create-chat.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsNotEmpty, IsUUID } from 'class-validator';
+
+export class CreateChatDto {
+  @ApiProperty({
+    example: '61c674384-f944-401b-949b-b76e8793bdc9',
+    description: 'The ID of the first user',
+  })
+  @IsNotEmpty()
+  @IsUUID()
+  userId1: string;
+
+  @ApiProperty({
+    example: '61c674384-f944-401b-949b-b76e8793bdc9',
+    description: 'The ID of the second user',
+  })
+  @IsNotEmpty()
+  @IsUUID()
+  userId2: string;
+}

--- a/src/modules/chat/dto/message-response.dto.ts
+++ b/src/modules/chat/dto/message-response.dto.ts
@@ -3,27 +3,19 @@ import { ApiProperty } from '@nestjs/swagger';
 import { ChatUserDto } from './chat-user.dto';
 
 export class MessageResponseDto {
-  @ApiProperty({
-    example: '61c674384-f944-401b-949b-b76e8793bdc9',
-    description: 'The ID of the message',
-  })
+  @ApiProperty()
   id: string;
 
-  @ApiProperty({
-    example: 'Hello, world!',
-    description: 'The content of the message',
-  })
+  @ApiProperty()
   content: string;
 
-  @ApiProperty({
-    example: '2024-07-22T14:09:59.234Z',
-    description: 'The timestamp when the message was created',
-  })
+  @ApiProperty()
   createdAt: Date;
 
-  @ApiProperty({
-    type: () => ChatUserDto,
-    description: 'The sender of the message',
-  })
+  @ApiProperty()
   sender: ChatUserDto;
+
+  constructor(partial: Partial<MessageResponseDto>) {
+    Object.assign(this, partial);
+  }
 }

--- a/src/modules/chat/dto/message-response.dto.ts
+++ b/src/modules/chat/dto/message-response.dto.ts
@@ -3,16 +3,28 @@ import { ApiProperty } from '@nestjs/swagger';
 import { ChatUserDto } from './chat-user.dto';
 
 export class MessageResponseDto {
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Unique identifier of the message',
+    example: '7b4b5875-2d0c-4bee-924a-1bdc7e6d3ef4',
+  })
   id: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Content of the message',
+    example: 'Hello, how are you?',
+  })
   content: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Timestamp when the message was created',
+    example: '2024-07-24T09:38:17.495Z',
+  })
   createdAt: Date;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Details of the user who sent the message',
+    type: ChatUserDto,
+  })
   sender: ChatUserDto;
 
   constructor(partial: Partial<MessageResponseDto>) {

--- a/src/modules/chat/dto/send-message.dto.ts
+++ b/src/modules/chat/dto/send-message.dto.ts
@@ -12,10 +12,4 @@ export class SendMessageDto {
     description: 'The content of the message',
   })
   content: string;
-
-  @ApiProperty({
-    example: '61c674384-f944-401b-949b-b76e8793bdc9',
-    description: 'The ID of the sender',
-  })
-  senderId: string;
 }

--- a/src/modules/chat/dto/send-message.dto.ts
+++ b/src/modules/chat/dto/send-message.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SendMessageDto {
+  @ApiProperty({
+    example: '61c674384-f944-401b-949b-b76e8793bdc9',
+    description: 'The ID of the chat',
+  })
+  chatId: string;
+
+  @ApiProperty({
+    example: 'Hello, world!',
+    description: 'The content of the message',
+  })
+  content: string;
+
+  @ApiProperty({
+    example: '61c674384-f944-401b-949b-b76e8793bdc9',
+    description: 'The ID of the sender',
+  })
+  senderId: string;
+}

--- a/src/modules/chat/dto/user-typing.dto.ts
+++ b/src/modules/chat/dto/user-typing.dto.ts
@@ -8,14 +8,14 @@ export class UserTypingDto {
   chatId: string;
 
   @ApiProperty({
-    example: '61c674384-f944-401b-949b-b76e8793bdc9',
-    description: 'The ID of the user who is typing',
-  })
-  userId: string;
-
-  @ApiProperty({
     example: 'true',
     description: 'Typing status',
   })
   typing: boolean;
+
+  @ApiProperty({
+    example: '61c674384-f944-401b-949b-b76e8793bdc9',
+    description: 'The ID of the user who is typing',
+  })
+  userId?: string;
 }

--- a/src/modules/chat/dto/user-typing.dto.ts
+++ b/src/modules/chat/dto/user-typing.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserTypingDto {
+  @ApiProperty({
+    example: '61c674384-f944-401b-949b-b76e8793bdc9',
+    description: 'The ID of the chat',
+  })
+  chatId: string;
+
+  @ApiProperty({
+    example: '61c674384-f944-401b-949b-b76e8793bdc9',
+    description: 'The ID of the user who is typing',
+  })
+  userId: string;
+
+  @ApiProperty({
+    example: 'true',
+    description: 'Typing status',
+  })
+  typing: boolean;
+}

--- a/src/modules/events/events.gateway.ts
+++ b/src/modules/events/events.gateway.ts
@@ -1,18 +1,71 @@
+import { Logger, UseGuards } from '@nestjs/common';
 import {
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  OnGatewayInit,
   SubscribeMessage,
   WebSocketGateway,
   WebSocketServer,
 } from '@nestjs/websockets';
 
-import { Server } from 'socket.io';
+import { Server, Socket } from 'socket.io';
 
+import { JwtAuthGuard } from '../auth/auth.guard';
+import { ChatService } from '../chat/chat.service';
+import { CreateChatDto } from '../chat/dto/create-chat.dto';
+import { SendMessageDto } from '../chat/dto/send-message.dto';
+import { ChatRoom } from '../chat/entities/chat-room.entity';
+import { Message } from '../chat/entities/message.entity';
+
+UseGuards(JwtAuthGuard);
 @WebSocketGateway({ cors: { origin: '*' } })
-export class EventsGateway {
+export class EventsGateway
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+{
+  private readonly Logger = new Logger(EventsGateway.name);
+
   @WebSocketServer()
   server: Server;
 
-  @SubscribeMessage('message')
-  handleMessage(): string {
-    return 'Hello world!';
+  constructor(private readonly chatService: ChatService) {}
+
+  afterInit(): void {
+    this.Logger.log('WebSocket server initialized');
+  }
+
+  handleConnection(client: Socket): void {
+    this.Logger.log(`Client connected: ${client.id}`);
+  }
+
+  handleDisconnect(client: Socket): void {
+    this.Logger.log(`Client disconnected: ${client.id}`);
+  }
+
+  @SubscribeMessage('createChat')
+  async handleCreateChat(
+    client: Socket,
+    createChatDto: CreateChatDto,
+  ): Promise<ChatRoom> {
+    const chatRoom = await this.chatService.createChat(createChatDto);
+
+    chatRoom.participants.forEach((participant) => client.join(participant.id));
+
+    this.server.to(chatRoom.id).emit('newChat', chatRoom);
+
+    this.server.emit('Chat created', createChatDto);
+
+    return chatRoom;
+  }
+
+  @SubscribeMessage('sendMessage')
+  async handleSendMessage(
+    client: Socket,
+    sendMessageDto: SendMessageDto,
+  ): Promise<Message> {
+    const message = await this.chatService.sendMessage(sendMessageDto);
+
+    this.server.to(message.chatRoom.id).emit('newMessage', message);
+
+    return message;
   }
 }

--- a/src/modules/events/events.gateway.ts
+++ b/src/modules/events/events.gateway.ts
@@ -124,9 +124,10 @@ export class EventsGateway
 
   @SubscribeMessage('userTyping')
   async handleUserTyping(
-    client: Socket,
+    client: SocketWithAuth,
     userTypingDto: UserTypingDto,
   ): Promise<void> {
+    userTypingDto.userId = client.userId;
     this.server.to(userTypingDto.chatId).emit('userTyping', userTypingDto);
   }
 }

--- a/src/modules/events/events.gateway.ts
+++ b/src/modules/events/events.gateway.ts
@@ -14,6 +14,7 @@ import { JwtAuthGuard } from '../auth/auth.guard';
 import { ChatService } from '../chat/chat.service';
 import { CreateChatDto } from '../chat/dto/create-chat.dto';
 import { SendMessageDto } from '../chat/dto/send-message.dto';
+import { UserTypingDto } from '../chat/dto/user-typing.dto';
 import { ChatRoom } from '../chat/entities/chat-room.entity';
 import { Message } from '../chat/entities/message.entity';
 
@@ -67,5 +68,13 @@ export class EventsGateway
     this.server.to(message.chatRoom.id).emit('newMessage', message);
 
     return message;
+  }
+
+  @SubscribeMessage('userTyping')
+  async handleUserTyping(
+    client: Socket,
+    userTypingDto: UserTypingDto,
+  ): Promise<void> {
+    this.server.to(userTypingDto.chatId).emit('userTyping', userTypingDto);
   }
 }

--- a/src/modules/events/events.gateway.ts
+++ b/src/modules/events/events.gateway.ts
@@ -50,7 +50,7 @@ export class EventsGateway
 
     server.use(async (socket: SocketWithAuth, next) => {
       try {
-        const token = socket.handshake.query.token as string;
+        const token = socket.handshake.auth.token as string;
 
         if (!token) {
           next(new UnauthorizedException('No token provided'));

--- a/src/modules/events/events.module.ts
+++ b/src/modules/events/events.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
 
 import { ChatModule } from '../chat/chat.module';
+import { UsersModule } from '../users/users.module';
 
 import { EventsGateway } from './events.gateway';
 
 @Module({
   providers: [EventsGateway],
-  imports: [ChatModule],
+  imports: [ChatModule, JwtModule, UsersModule],
 })
 export class EventsModule {}

--- a/src/modules/events/events.module.ts
+++ b/src/modules/events/events.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 
+import { ChatModule } from '../chat/chat.module';
+
 import { EventsGateway } from './events.gateway';
 
 @Module({
   providers: [EventsGateway],
+  imports: [ChatModule],
 })
 export class EventsModule {}


### PR DESCRIPTION
## Describe your changes
- Configured the connection to the socket
- I added the possibility of creating a chat with another user
- I added the possibility of sending a message
- I added a listener to detect when the user is typing

<img width="1078" alt="Screenshot 2024-07-24 at 17 52 04" src="https://github.com/user-attachments/assets/26edb05b-762f-4dfa-88c3-fe51484505ea">
<img width="1079" alt="Screenshot 2024-07-24 at 17 53 28" src="https://github.com/user-attachments/assets/6b63da93-8ea4-4f30-9af0-7277690425d4">
<img width="1104" alt="Screenshot 2024-07-24 at 17 54 22" src="https://github.com/user-attachments/assets/ee0a56ef-c4ab-4549-9133-b971fc982eea">


## Issue ticket code (and/or) and link
- [Link to JIRA ticket](https://2024internship.atlassian.net/browse/SCRUM-259)
  
### **General**
- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [x] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Backend
- [x] Swagger documentation updated
- [x] Database requests are optimized and not redundant
- [ ] Unit tests written
- [x] use ConfigService instead of process.env
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] use @index decorator for frequently requested data